### PR TITLE
Update version of `mongodb` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-mongodb-session",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "MongoDB session store for connect/express built by MongoDB",
   "keywords": [
     "connect",
@@ -15,7 +15,7 @@
     "url": "https://github.com/mongodb-js/connect-mongodb-session.git"
   },
   "dependencies": {
-    "mongodb": "~2.1.0"
+    "mongodb": "~2.2.0"
   },
   "devDependencies": {
     "acquit": "0.1.0",


### PR DESCRIPTION
I ran into an issue yesterday using this module alongside [mongoose](https://github.com/Automattic/mongoose) 4.6.0
The incompatability between [mongodb](https://github.com/mongodb/node-mongodb-native) versions 2.1.x and 2.2.x was the issue.  I'm not sure if this PR is correct, but I thought I'd put it here in case anyone else has the same issue.

related:
https://github.com/Automattic/mongoose/issues/4349
https://github.com/mongodb/js-bson/issues/187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/connect-mongodb-session/28)
<!-- Reviewable:end -->
