### PR TITLE
Added 'clear()' to session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ module will manage the internal connection state for you.
   
 ```
 
+**Optional:** To clear all sessions from the store, use `store.clear(callback);`. 
+The callback should be called as `callback(error)`.
+
 #### It can store sessions for latest Express 3.x
 
 If you're using Express 3.x, you need to pass the Express module itself

--- a/index.js
+++ b/index.js
@@ -114,6 +114,24 @@ module.exports = function(connect) {
       });
   };
 
+  MongoDBStore.prototype.clear = function(callback) {
+    var _this = this;
+    if (!this.db) {
+      return this._emitter.once('connected', function() {
+        _this.clear.call(_this, callback);
+      });
+    }
+
+    this.db.collection(this.options.collection).
+      remove({}, function(error) {
+        if (error) {
+          var e = new Error('Error clearing all sessions: ' + error.message);
+          return _this._errorHandler(e, callback);
+        }
+        callback && callback();
+      });
+  };
+
   MongoDBStore.prototype.set = function(id, session, callback) {
     var _this = this;
 

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -101,7 +101,14 @@ describe('MongoDBStore', function() {
           };
           request(config, function(error, response, body) {
             assert.ok(!response.headers['set-cookie']);
-            done();
+            store.clear(function(error) {
+              assert.ifError(error);
+              underlyingDb.collection('mySessions').count({}, function(error, count) {
+                assert.ifError(error);
+                assert.equal(0, count);
+                done();
+              });
+            });
           });
         });
       });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -412,4 +412,33 @@ describe('connectMongoDBSession', function() {
       });
     });
   });
+
+  describe('clear()', function(done){
+    var numIndexCalls;
+
+    beforeEach(function() {
+      numIndexCalls = 0;
+
+      db.ensureIndex.on('called', function(args) {
+        assert.equal(++numIndexCalls, 1);
+        assert.equal(args.index.expires, 1);
+        args.callback();
+      });
+    });
+
+    it('clears the session store', function(done) {
+      var SessionStore = connectMongoDBSession({ Store: StoreStub });
+
+      var session = new SessionStore();
+      db.remove.on('called', function(args) {
+        args.callback(null);
+      });
+
+      session.clear(function(error) {
+        assert.ifError(error);
+        done();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
This is [one of the optional methods](https://github.com/expressjs/session#storeclearcallback) of the session store implementation in [expressjs/session](https://github.com/expressjs/session). I needed this implemented for a project at work, so I thought I might contribute.

This is my first pull request _ever_, so there's a good chance I screwed something up. Feedback is welcome.