### PR TITLE
emit expired event after destroying the session.

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ module.exports = function(connect) {
           var e = new Error('Error destroying ' + id + ': ' + error.message);
           return _this._errorHandler(e, callback);
         }
+        _this._emitter.emit('expired');
         callback && callback();
       });
   };


### PR DESCRIPTION
it would be very useful to have an event that inform us when the session is expired, 
I'm making two assumptions here, let me know if they are right. 
- the session is only destroyed when it expires.
- we want to notify that session expires only after we could destroy the session in the database.