### PR TITLE
Remove assert (ReferenceError: assert is not defined)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ var store = new MongoDBStore({
 
 // Catch errors
 store.on('error', function(error) {
-  console.log(`store error: ${error}`);
+  console.error(`store error: ${error}`);
 });
 
 app.use(require('express-session')({

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ var store = new MongoDBStore({
 
 // Catch errors
 store.on('error', function(error) {
-  assert.ifError(error);
-  assert.ok(false);
+  console.log(`store error: ${error}`);
 });
 
 app.use(require('express-session')({


### PR DESCRIPTION
Hey mate,

On lines 48-52:
// Catch errors
store.on('error', function(error) {
assert.ifError(error);
assert.ok(false);
});

You are using an assert function which is not imported.

I suggest that you either add the appropriate assert in the example code,
or (preferably) change the assert code to:
console.log(error),

Given that an average user of this package would not necessarily be interested in assertion at all,
And with the basic use case code example, usually we try to aim for the lowest common denominator of use cases.

Cheers