### PR TITLE
Replace assert with console.log

### DIFF
--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -67,7 +67,11 @@ describe('MongoDBStore', function() {
 
     // Catch errors
     store.on('error', function(error) {
-      console.log(error),
+      console.log(error);
+      // acquit:ignore:start
+      assert.ifError(error);
+	    assert.ok(false);
+      // acquit:ignore:end
     });
 
     app.use(require('express-session')({

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -67,8 +67,7 @@ describe('MongoDBStore', function() {
 
     // Catch errors
     store.on('error', function(error) {
-      assert.ifError(error);
-      assert.ok(false);
+      console.log(error),
     });
 
     app.use(require('express-session')({


### PR DESCRIPTION
Hey mate,

On lines 48-52:
// Catch errors
store.on('error', function(error) {
assert.ifError(error);
assert.ok(false);
});

You are using an assert function which is not imported.

Anyone who just attempts to npm install the package and use it would get a frustrating:
(ReferenceError: assert is not defined) 

I suggest that you either add the appropriate assert in the example code,
or (preferably) change the assert code to:
console.log(error),

Given that an average user of this package would not necessarily be interested in assertion at all,
And with the basic use case code example, usually we try to aim for the lowest common denominator of use cases.

Cheers