### PR TITLE
Updates dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/mongodb-js/connect-mongodb-session.git"
   },
   "dependencies": {
-    "archetype": "0.8.x",
+    "archetype": "0.10.x",
     "mongodb": "3.5.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "acquit-ignore": "0.1.0",
     "acquit-markdown": "0.1.0",
     "cookie": "0.3.1",
-    "express": "4.14.0",
+    "express": "4.17.0",
     "express-session": "1.15.2",
     "istanbul": "0.4.5",
     "mocha": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mongodb": "3.5.x"
   },
   "devDependencies": {
-    "acquit": "1.0.0",
+    "acquit": "1.0.5",
     "acquit-ignore": "0.1.0",
     "acquit-markdown": "0.1.0",
     "cookie": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "archetype": "0.8.x",
-    "mongodb": "3.2.x"
+    "mongodb": "3.5.x"
   },
   "devDependencies": {
     "acquit": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "acquit-markdown": "0.1.0",
     "cookie": "0.3.1",
     "express": "4.17.0",
-    "express-session": "1.15.2",
+    "express-session": "1.17.0",
     "istanbul": "0.4.5",
     "mocha": "3.1.2",
     "strawman": "0.0.1",


### PR DESCRIPTION
Updates production dependencies to:
* archetype 0.10.0
* mongodb 3.5.0

Update dev dependencies to:
* acquit 1.0.5
* express 4.17.0
* express-session 1.17.0

Dev dependencies updated because of vulnerabilities complaints by npm. I did not update mocha because latest version causes `npm test` to hang around forever.