### PR TITLE
Bump archetype dependency to 0.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/mongodb-js/connect-mongodb-session.git"
   },
   "dependencies": {
-    "archetype": "0.10.x",
+    "archetype": "0.11.x",
     "mongodb": "3.5.x"
   },
   "devDependencies": {


### PR DESCRIPTION
`archetype` contained a cyclic import which is fixed by https://github.com/boosterfuels/archetype/pull/21

This PR just bumps the version of this dependency pulled to 0.11.x instead, which should be enough to also pull the future patches.