### PR TITLE
Set expireAfterSeconds in index to 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ module.exports = function(connect) {
 
       db.
         collection(options.collection).
-        createIndex({ expires: 1 }, { expireAfterSeconds: 0 }, function(error) {
+        createIndex({ expires: 1 }, { expireAfterSeconds: 1 }, function(error) {
           if (error) {
             const e = new Error('Error creating index: ' + error.message);
             return _this._errorHandler(e, callback);


### PR DESCRIPTION
We have an issue where expired sessions are not deleted properly even though there is a ttl index, so I checked the ttl index that is created by the library.

As it turns out, according to the mongodb documentation, expireAfterSeconds needs to be a positive, non-zero value in order for the ttl index to actually work. (see https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds)